### PR TITLE
UML-2531 - Add public ingress for production

### DIFF
--- a/terraform/account/modules/region/kms.tf
+++ b/terraform/account/modules/region/kms.tf
@@ -62,6 +62,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
     principals {
       type = "AWS"
       identifiers = [
+        data.aws_default_tags.current.tags.environment-name == "development" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator" : null,
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass",
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/opg-maintenance-ci",
       ]

--- a/terraform/environment/modules/region/maintenance_load_balancer.tf
+++ b/terraform/environment/modules/region/maintenance_load_balancer.tf
@@ -105,6 +105,18 @@ resource "aws_security_group_rule" "maintenance_loadbalancer_ingress" {
   provider          = aws.region
 }
 
+resource "aws_security_group_rule" "maintenance_loadbalancer_production_ingress" {
+  count             = data.aws_default_tags.current.tags.environment-name == "production" ? 1 : 0
+  description       = "Port 443 production public ingress to the application load balancer"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007 - open ingress for production
+  security_group_id = aws_security_group.maintenance_loadbalancer.id
+  provider          = aws.region
+}
+
 resource "aws_security_group_rule" "maintenance_loadbalancer_egress" {
   description       = "Allow any egress from Use service load balancer"
   type              = "egress"


### PR DESCRIPTION
# Purpose

Allow the public to view maintenance pages

Fixes UML-2531

## Approach

- add public ingress on production
- make operator a kms key admin for dev account (makes team use of dev easier)

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
