### PR TITLE
UML-2537 - Add planned downtime pages for UAL service

### DIFF
--- a/service-maintenance/internal/server/server.go
+++ b/service-maintenance/internal/server/server.go
@@ -47,6 +47,11 @@ func NewServer() http.Handler {
 	router.Handle("/en-gb/view-a-lasting-power-of-attorney", handlers.StaticMaintenanceHandler("View a LPA English", "val_en_maintenance.page.gohtml"))
 	router.Handle("/cy/gweld-atwrneiaeth-arhosol", handlers.StaticMaintenanceHandler("View a LPA Welsh", "val_cy_maintenance.page.gohtml"))
 
+	router.Handle("/en-gb/use-a-lasting-power-of-attorney/planned", handlers.StaticMaintenanceHandler("Use a LPA English Planned Downtime", "ual_en_planned_maintenance.page.gohtml"))
+	router.Handle("/cy/defnyddio-atwrneiaeth-arhosol/planned", handlers.StaticMaintenanceHandler("Use a LPA Welsh Planned Downtime", "ual_cy_planned_maintenance.page.gohtml"))
+	router.Handle("/en-gb/view-a-lasting-power-of-attorney/planned", handlers.StaticMaintenanceHandler("View a LPA English Planned Downtime", "val_en_planned_maintenance.page.gohtml"))
+	router.Handle("/cy/gweld-atwrneiaeth-arhosol/planned", handlers.StaticMaintenanceHandler("View a LPA Welsh Planned Downtime", "val_cy_planned_maintenance.page.gohtml"))
+
 	router.PathPrefix("/").Handler(handlers.StaticHandler(os.DirFS("web/static")))
 
 	wrap := WithJSONLogging(

--- a/service-maintenance/web/templates/ual_cy_planned_maintenance.page.gohtml
+++ b/service-maintenance/web/templates/ual_cy_planned_maintenance.page.gohtml
@@ -1,0 +1,11 @@
+{{ template "default" . }}
+
+{{ define "title" }}Cynnal a chadw | Defnyddio atwrneiaeth arhosol | GOV.UK{{ end }}
+
+{{ define "main" }}
+  <h1 class="govuk-heading-xl">Mae’n ddrwg gennym, nid yw’r gwasanaeth ar gael</h1>
+  <p class="govuk-body">Bydd y gwasanaeth hwn ar gael unwaith eto o 4y.p Dydd Sadwrn 9 Gorffennaf 2022.</p>
+  <p class="govuk-body">Os oes arnoch angen defnyddio'ch atwrneiaeth arhosol cyn yr amser hwn, gallwch barhau i ddefnyddio'r LPA bapur.</p>
+  <p class="govuk-body">Back to GOV.UK: <a class="govuk-link" href="https://www.gov.uk/defnyddio-atwrneiaeth-arhosol">www.gov.uk/defnyddio-atwrneiaeth-arhosol</a>
+  </p>
+{{ end }}

--- a/service-maintenance/web/templates/ual_en_planned_maintenance.page.gohtml
+++ b/service-maintenance/web/templates/ual_en_planned_maintenance.page.gohtml
@@ -1,0 +1,11 @@
+{{ template "default" . }}
+
+{{ define "title" }}Maintenance | Use a lasting power of attorney | GOV.UK{{ end }}
+
+{{ define "main" }}
+  <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+  <p class="govuk-body">You will be able to use the service again from 4pm Saturday 9 July.</p>
+  <p class="govuk-body">If you need to use your lasting power of attorney before this time you can still use the paper LPA document.</p>
+  <p class="govuk-body">Back to GOV.UK: <a class="govuk-link" href="https://www.gov.uk/use-lasting-power-of-attorney">www.gov.uk/use-lasting-power-of-attorney</a>
+  </p>
+{{ end }}

--- a/service-maintenance/web/templates/val_cy_planned_maintenance.page.gohtml
+++ b/service-maintenance/web/templates/val_cy_planned_maintenance.page.gohtml
@@ -1,0 +1,10 @@
+{{ template "default" . }}
+
+{{ define "title" }}Cynnal a chadw | Gweld atwrneiaeth arhosol | GOV.UK{{ end }}
+
+{{ define "main" }}
+  <h1 class="govuk-heading-xl">Mae’n ddrwg gennym, ond nid yw’r gwasanaeth ar gael ar hyn o bryd.</h1>
+  <p class="govuk-body">Bydd y gwasanaeth hwn ar gael unwaith eto o 4y.p Dydd Sadwrn 9 Gorffennaf 2022.</p>
+  <p class="govuk-body">Back to GOV.UK: <a class="govuk-link" href="https://www.gov.uk/gweld-atwrneiaeth-arhosol">www.gov.uk/gweld-atwrneiaeth-arhosol</a>
+  </p>
+{{ end }}

--- a/service-maintenance/web/templates/val_en_planned_maintenance.page.gohtml
+++ b/service-maintenance/web/templates/val_en_planned_maintenance.page.gohtml
@@ -1,0 +1,10 @@
+{{ template "default" . }}
+
+{{ define "title" }}Maintenance | View a lasting power of attorney | GOV.UK{{ end }}
+
+{{ define "main" }}
+  <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+  <p class="govuk-body">You will be able to use the service again from 4pm Saturday 9 July 2022.</p>
+  <p class="govuk-body">Back to GOV.UK: <a class="govuk-link" href="https://www.gov.uk/view-lasting-power-of-attorney">www.gov.uk/view-lasting-power-of-attorney</a>
+  </p>
+{{ end }}


### PR DESCRIPTION
# Purpose

Prepare for downtime of the UaL service

Fixes UML-2537

## Approach

- Add templates for planned downtime in welsh and english
- create routes for planned downtime

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* ~I have added tests to prove my work~
* [x] I have added welsh translation tags and updated translation files
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [x] The product team have tested these changes
