### PR TITLE
prefix maintenance to environment name when managing deployments

### DIFF
--- a/.github/workflows/path_to_live_workflow.yml
+++ b/.github/workflows/path_to_live_workflow.yml
@@ -66,7 +66,7 @@ jobs:
     name: End of Main Workflow
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: production
+    environment: maintenance_production
     needs: [production_deploy]
     steps:
       - name: End of PR Workflow

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -67,7 +67,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
-      name: "maintenance-${{ needs.create_tags.outputs.environment_workspace_name }}"
+      name: "maintenance_dev_${{ needs.create_tags.outputs.environment_workspace_name }}"
       url: "${{ needs.pr_deploy.outputs.terraform_maintenance_url }}/maintenance"
     needs: [pr_deploy, create_tags]
     steps:

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -67,7 +67,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
-      name: ${{ needs.create_tags.outputs.environment_workspace_name }}
+      name: "maintenance-${{ needs.create_tags.outputs.environment_workspace_name }}"
       url: "${{ needs.pr_deploy.outputs.terraform_maintenance_url }}/maintenance"
     needs: [pr_deploy, create_tags]
     steps:


### PR DESCRIPTION
# Purpose

Differentiate maintenance github environments from other product github environments in JIRA

Fixes UML-2507

## Approach

- prefix `maintenance_dev_' to environment name during `end-of-workflow` job
- set `maintenance_production' to environment name during `end-of-workflow` job

## Learning

- https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#about-environments

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
